### PR TITLE
Remover print supérfluo do cloud_ocr

### DIFF
--- a/cloud_ocr/cloud_ocr.py
+++ b/cloud_ocr/cloud_ocr.py
@@ -96,4 +96,4 @@ def OCR_Single_Image(path: str) -> str:
         raise
 
 
-print(__file__)
+# print(__file__)


### PR DESCRIPTION
## Summary
- comentar chamada `print(__file__)` no módulo `cloud_ocr`

## Testing
- `python -m py_compile cloud_ocr/cloud_ocr.py`

------
https://chatgpt.com/codex/tasks/task_e_68547f7fe3088322a0142e0573851da5