### PR TITLE
Fix processed path in recognizer

### DIFF
--- a/cloud_ocr/recognizer.py
+++ b/cloud_ocr/recognizer.py
@@ -95,6 +95,7 @@ def Recognize() -> None:
 
         else:
             progress_files = ProgressBar(len(files), "Processing files", "file")
+            os.makedirs(os.path.join("Processos", "Processed"), exist_ok=True)
 
             for file in files:
                 try:
@@ -103,7 +104,8 @@ def Recognize() -> None:
                     output_path = os.path.join("Output", f"{name}.txt")
 
                     _process_pdf(file_path, output_path)
-                    shutil.move(file_path, os.path.join(file_path, f"./Processos/Processed/{name}.pdf"))
+                    dest = os.path.join("Processos", "Processed", f"{name}.pdf")
+                    shutil.move(file_path, dest)
                     progress_files.update(1)
 
                 except Exception as e:


### PR DESCRIPTION
## Summary
- ensure `Processos/Processed` folder exists before moving files
- use proper destination path when moving processed PDFs

## Testing
- `python -m py_compile cloud_ocr/recognizer.py`

------
https://chatgpt.com/codex/tasks/task_e_68547ee9ed00832286708426a11df0c1